### PR TITLE
OpenLog: avoid crash when log file is missing

### DIFF
--- a/Setting.cs
+++ b/Setting.cs
@@ -322,11 +322,47 @@ namespace PrefabAssetFixes
         {
             set
             {
-                Task.Run(() =>
-                    Process.Start($"{EnvPath.kUserDataPath}/Logs/{nameof(PrefabAssetFixes)}.log")
-                );
+                string logPath = $"{EnvPath.kUserDataPath}/Logs/{nameof(PrefabAssetFixes)}.log";
+                string? logsDir = System.IO.Path.GetDirectoryName(logPath);
+
+                try
+                {
+                    if (System.IO.File.Exists(logPath))
+                    {
+                        var psi = new ProcessStartInfo(logPath)
+                        {
+                            UseShellExecute = true,  // open with default editor
+                            ErrorDialog = false,
+                            Verb = "open"
+                        };
+                        Process.Start(psi);
+                        return;
+                    }
+
+                    // No file yet — open the Logs folder instead
+                    if (!string.IsNullOrEmpty(logsDir) && System.IO.Directory.Exists(logsDir))
+                    {
+                        var psi2 = new ProcessStartInfo(logsDir)
+                        {
+                            UseShellExecute = true,
+                            ErrorDialog = false,
+                            Verb = "open"
+                        };
+                        Process.Start(psi2);
+                    }
+                    else
+                    {
+                        LogHelper.SendLog("[OpenLog] No log file yet, and Logs folder not found.", LogLevel.Info);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Single catch handles Win32Exception and anything else safely
+                    LogHelper.SendLog($"[OpenLog] Failed to open path: {ex.GetType().Name}: {ex.Message}", LogLevel.Warn);
+                }
             }
         }
+
 
         public override void SetDefaults()
         {


### PR DESCRIPTION
**Changes**
- If the log file exists, open it via ProcessStartInfo
- If not, open the Logs folder instead; otherwise log a note.
- Single try/catch guards for Win32Exception and other failures (no crash).
- Removed Task.Run (not needed for this)
- Sending  Setting.cs only.

**Tested: no more crashes**

1. Start game, do not  load any city yet.
2. Open Options >> Prefab Asset Fixes  > click [Open Log] button
3. If no log file yet, it will open the Logs folder - no crash 

Sidenote - noticed  Setting.cs  is not needing  `using System.Threading.Tasks;`